### PR TITLE
feat: mux

### DIFF
--- a/spice/src/circuits/gates.cir
+++ b/spice/src/circuits/gates.cir
@@ -34,7 +34,7 @@
    xMP2 1 B Q 1 pmos1v l=L w=W
 
    * NMOS section
-   xMN1 Q A 1 1 nmos1v l=L w=W
+   xMN1 Q A Vss Vss nmos1v l=L w=W
    xMN2 Q B Vss Vss nmos1v l=L w=W
 .ends NOR
 

--- a/spice/src/circuits/gates.cir
+++ b/spice/src/circuits/gates.cir
@@ -50,4 +50,10 @@
    xAND2 C intermediate Q Vdd Vss AND
 .ends
 
+* 3OR gate
+.subckt 3OR A B C Q Vdd Vss
+   xOR1 A B intermediate Vdd Vss OR
+   xOR2 C intermediate Q Vdd Vss OR
+.ends
+
 

--- a/spice/src/circuits/gates.cir
+++ b/spice/src/circuits/gates.cir
@@ -47,13 +47,13 @@
 * 3AND gate
 .subckt 3AND A B C Q Vdd Vss
    xAND1 A B intermediate Vdd Vss AND
-   xAND2 C intermediate Q Vdd Vss AND
+   xAND2 intermediate C Q Vdd Vss AND
 .ends
 
 * 3OR gate
 .subckt 3OR A B C Q Vdd Vss
    xOR1 A B intermediate Vdd Vss OR
-   xOR2 C intermediate Q Vdd Vss OR
+   xOR2 intermediate C Q Vdd Vss OR
 .ends
 
 

--- a/spice/src/circuits/mux.cir
+++ b/spice/src/circuits/mux.cir
@@ -1,0 +1,16 @@
+* MUX subcircuit
+.subckt MUX A B C S1 S2 OUT Vdd Vss
+   * AND gates
+   x3AND1 1 2 A 5 Vdd Vss 3AND
+   x3AND2 S1 3 B 6 Vdd Vss 3AND
+   x3AND3 4 S2 C 7 Vdd Vss 3AND
+
+   * OR gate
+   x3OR 5 6 7 OUT Vdd Vss 3OR
+
+   * NOT gates
+   xNOT1 S1 1 Vdd Vss NOT
+   xNOT2 S2 2 Vdd Vss NOT
+   xNOT3 S2 3 Vdd Vss NOT
+   xNOT4 S1 4 Vdd Vss NOT
+.ends

--- a/spice/src/inlcludes.cir.example
+++ b/spice/src/inlcludes.cir.example
@@ -3,3 +3,6 @@
 
 * include gate subcircuits
 .include [ absolute path to gates file ]
+
+* include mux subcircuit
+.include [ absolute path to mux file ]

--- a/spice/src/main.cir
+++ b/spice/src/main.cir
@@ -7,17 +7,21 @@
 * params
 .param supplyVoltage = 1
 
-* circuit
+* * MUX test
 Vdd Vdd 0 supplyVoltage
 
-Va A 0 PULSE(0, supplyVoltage, 10n, 1n, 1n, 10n, 30n)
-Vb B 0 PULSE(0, supplyVoltage, 5n, 1n, 1n, 10n, 30n)
-Vc C 0 PULSE(0, supplyVoltage, 0n, 1n, 1n, 10n, 30n)
+Va A 0 0
+Vb B 0 0
+Vc C 0 supplyVoltage
 
-x3AND A B C Q Vdd 0 3AND
+VS1 S1 0 PULSE(0, supplyVoltage, 13n, 1n, 1n, 7n, 20n)
+VS2 S2 0 PULSE(0, supplyVoltage, 10n, 1n, 1n, 10n, 30n)
+
+xMUX A B C S1 S2 OUT Vdd 0 MUX
 
 * plots
-.plot v(Q) V(A) V(B) V(C)
+.plot v(OUT) v(S1) v(S2)
+.plot v(OUT)
 
 * analasys
 .tran 1n 60n


### PR DESCRIPTION
# Changes
- Fix error in _OR_ gate subcircuit :grimacing: I have also verified that all the gates work as intended.
- Add _3OR_ gate.
- Add _MUX_ subcircuit.

# Verification

- MUX inputs: `A = 1` `B = 0` `C = 0`
<img width="400" alt="MUX_A=1_B=0_C=0" src="https://github.com/AasmundN/mac-unit/assets/48122613/4404136c-9d15-422a-a69c-cc2ba0bc998c">

- MUX inputs: `A = 0` `B = 1` `C = 0`
<img width="400" alt="MUX_A=0_B=1_C=0" src="https://github.com/AasmundN/mac-unit/assets/48122613/79c4db9a-c44a-4f43-b630-1758846b3043">

- MUX inputs: `A = 0` `B = 0` `C = 1`
<img width="400" alt="MUX_A=0_B=0_C=1" src="https://github.com/AasmundN/mac-unit/assets/48122613/72363fba-549a-42b3-821a-881688a6cd8f">

- The verification confirms that the circuit behaves as expected 💪 

|  $S_2$ | $S_1$ | $OUT$ | 
|---|---|---|
|  0 | 0  | A  |
|  0 |  1 | B  |
| 1  | 0  | C  |